### PR TITLE
mkdir `-p` after dir creates new folder in some bash/zsh implementations

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 echo "Here we go!"
-mkdir ./target/app/ -p
+mkdir -p ./target/app/
 cp ./src/main/css/*.css ./target/app/
 cp ./src/main/js/*.js ./target/app/
 cp ./src/main/html/*.html ./target/app/


### PR DESCRIPTION
Specifically it makes a "-p" folder on macOS, which is kinda funny.

Not sure what spec should be for mkdir, tried both bash and zsh, both did the same thing I think.